### PR TITLE
Fixes issue where postcss (needed for tailwindcss) broke during production builds.

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,6 @@
-const postcssConfig = {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
   },
 };
-
-export default postcssConfig;


### PR DESCRIPTION
This PR changes the file `postcss.config.mjs` back to `postcss.config.js`. This is needed to fix an issue where postcss (needed for tailwindcss) broke during production builds, leaving us with with mostly unstyled pages.

To test: checkout the branch, *delete your `.next` build directory*, then run `pnpm run build` and `pnpm run start` and make sure page has styling. 