### PR TITLE
Adds expression handling for Dynamic Render with PlainText support 

### DIFF
--- a/src/features/dynamicRender/components/ui/Text.tsx
+++ b/src/features/dynamicRender/components/ui/Text.tsx
@@ -11,7 +11,7 @@ type TextAttributes = { textContent: ExpressionDescriptor };
 const attributeDefinitions: AttributeDefinition[] = [];
 
 /**
- * Renders a group of Pages that can be shown one at a time
+ * Renders text content
  */
 export function Text(props: RenderComponentProps<TextAttributes>) {
   const textContent = useExpression(props.attributes.textContent);

--- a/src/features/dynamicRender/components/ui/Text.tsx
+++ b/src/features/dynamicRender/components/ui/Text.tsx
@@ -1,18 +1,21 @@
+import { useExpression } from "features/dynamicRender/hooks/useExpression";
 import { AttributeDefinition } from "features/dynamicRender/types/attributes/definition";
+import { ExpressionDescriptor } from "features/dynamicRender/types/expression";
 import { NodeType } from "features/dynamicRender/types/node";
 import {
   RenderComponentDefinition,
   RenderComponentProps,
 } from "features/dynamicRender/types/render";
 
-type TextAttributes = { text: string };
+type TextAttributes = { textContent: ExpressionDescriptor };
 const attributeDefinitions: AttributeDefinition[] = [];
 
 /**
  * Renders a group of Pages that can be shown one at a time
  */
 export function Text(props: RenderComponentProps<TextAttributes>) {
-  return <>{props.node.textContent?.trim()}</>;
+  const textContent = useExpression(props.attributes.textContent);
+  return <>{textContent}</>;
 }
 
 export const textBundle: RenderComponentDefinition<TextAttributes> = {

--- a/src/features/dynamicRender/components/utility/Void.tsx
+++ b/src/features/dynamicRender/components/utility/Void.tsx
@@ -1,15 +1,14 @@
+import { Attributes } from "features/dynamicRender/types/attributes";
 import { NodeType } from "features/dynamicRender/types/node";
 import {
   RenderComponentDefinition,
   RenderComponentProps,
 } from "features/dynamicRender/types/render";
 
-type VoidAttributes = object;
-
 /**
  * A non-usable component that prints errors depending on Debug requirements
  */
-export function Void(props: RenderComponentProps<VoidAttributes>) {
+export function Void(props: RenderComponentProps<Attributes>) {
   return (
     <>
       This component ({props.nodeName}, {props.nodeType}) was not able to render correctly
@@ -17,7 +16,7 @@ export function Void(props: RenderComponentProps<VoidAttributes>) {
   );
 }
 
-export const voidBundle: RenderComponentDefinition<VoidAttributes> = {
+export const voidBundle: RenderComponentDefinition<Attributes> = {
   Component: Void,
   nodeType: NodeType.Void,
   attributeDefinitions: [],

--- a/src/features/dynamicRender/hooks/useExpression.spec.ts
+++ b/src/features/dynamicRender/hooks/useExpression.spec.ts
@@ -1,0 +1,27 @@
+import { __testing__ } from "features/dynamicRender/hooks/useExpression";
+import { ExpressionType, PlainTextExpression } from "features/dynamicRender/types/expression";
+
+const { getInitialValue } = __testing__;
+
+describe("get initial value tests", () => {
+  it("returns a string without changing it", () => {
+    const testStr = "test";
+    const res = getInitialValue(testStr);
+    expect(res).toBe(testStr);
+  });
+
+  it("handles invalid types safely", () => {
+    const res = getInitialValue(1234 as unknown as string);
+    expect(res).toBe("");
+  });
+
+  it("returns plaintext expressions", () => {
+    const plainTextExpression: PlainTextExpression = {
+      type: ExpressionType.PlainText,
+      value: "test",
+    };
+
+    const res = getInitialValue(plainTextExpression);
+    expect(res).toBe(plainTextExpression.value);
+  });
+});

--- a/src/features/dynamicRender/hooks/useExpression.ts
+++ b/src/features/dynamicRender/hooks/useExpression.ts
@@ -34,3 +34,5 @@ function getInitialValue(expression: ExpressionDescriptor | string) {
   if (expression.type === ExpressionType.PlainText) return expression.value;
   return "";
 }
+
+export const __testing__ = { getInitialValue };

--- a/src/features/dynamicRender/hooks/useExpression.ts
+++ b/src/features/dynamicRender/hooks/useExpression.ts
@@ -1,0 +1,36 @@
+import { ExpressionDescriptor, ExpressionType } from "features/dynamicRender/types/expression";
+import { useEffect, useMemo, useState } from "react";
+
+/**
+ * Evaluates an expression, processing it safely through a Web Worker,
+ * and returning the result to be used.
+ * This will safely handle the accidental use of a string instead of a proper
+ * expression, though no evaluation will be done.
+ * @param expression - The expression to evaluate
+ * @returns A string value of the evaluated result
+ */
+export function useExpression(expression: ExpressionDescriptor | string): string {
+  const initialValue = useMemo(() => getInitialValue(expression), [expression]);
+  const [value, setValue] = useState(initialValue);
+
+  useEffect(() => {
+    if (typeof expression !== "object") return;
+    if (expression.type === ExpressionType.PlainText) return;
+    setValue("TODO");
+  });
+
+  return value;
+}
+
+/**
+ * Determines the initial value of a given expression
+ * @param expression - The expression descriptor to evaluate for an initial value
+ * @returns The initial value as a string. If undetermined, an empty string
+ */
+function getInitialValue(expression: ExpressionDescriptor | string) {
+  if (typeof expression === "string") return expression;
+  else if (typeof expression !== "object") return "";
+
+  if (expression.type === ExpressionType.PlainText) return expression.value;
+  return "";
+}

--- a/src/features/dynamicRender/types/attributes/definition.ts
+++ b/src/features/dynamicRender/types/attributes/definition.ts
@@ -6,4 +6,6 @@ export type AttributeDefinition = {
   default?: string;
   /** If the attribute is required */
   required?: boolean;
+  /** Indicates that this attribute supports expressions */
+  supportsExpressions?: boolean;
 };

--- a/src/features/dynamicRender/types/attributes/index.ts
+++ b/src/features/dynamicRender/types/attributes/index.ts
@@ -1,0 +1,7 @@
+import { ExpressionDescriptor } from "features/dynamicRender/types/expression";
+
+/** A record of all found and present attributes for a parsed element */
+export type Attributes = Record<string, Attribute>;
+
+/** A single attribute that is parsed and usable in a render */
+export type Attribute = string | ExpressionDescriptor;

--- a/src/features/dynamicRender/types/expression.ts
+++ b/src/features/dynamicRender/types/expression.ts
@@ -1,0 +1,21 @@
+export type ExpressionDescriptor = InvalidExpression | PlainTextExpression;
+
+/** Describes an Invalid Expression, the given value and the reason why it fails */
+export type InvalidExpression = {
+  type: ExpressionType.Invalid;
+  value: string | undefined;
+  why: string;
+};
+
+/** Describes an expression that's simply plain text that requires no evaluation */
+export type PlainTextExpression = {
+  type: ExpressionType.PlainText;
+  value: string;
+};
+
+export enum ExpressionType {
+  /** This expression is invalid for some reason or another */
+  Invalid,
+  /** This expression is plain text and does not require evaluation */
+  PlainText,
+}

--- a/src/features/dynamicRender/types/expression.ts
+++ b/src/features/dynamicRender/types/expression.ts
@@ -1,3 +1,4 @@
+/** Describes an expression and how to evaluate it */
 export type ExpressionDescriptor = InvalidExpression | PlainTextExpression;
 
 /** Describes an Invalid Expression, the given value and the reason why it fails */

--- a/src/features/dynamicRender/types/expression.ts
+++ b/src/features/dynamicRender/types/expression.ts
@@ -13,6 +13,7 @@ export type PlainTextExpression = {
   value: string;
 };
 
+/** The types of expressions, describing the sort of processing they will need */
 export enum ExpressionType {
   /** This expression is invalid for some reason or another */
   Invalid,

--- a/src/features/dynamicRender/types/render.ts
+++ b/src/features/dynamicRender/types/render.ts
@@ -1,3 +1,4 @@
+import { Attributes } from "features/dynamicRender/types/attributes";
 import { AttributeDefinition } from "features/dynamicRender/types/attributes/definition";
 import { NodeType } from "features/dynamicRender/types/node";
 import { ReactNode } from "react";
@@ -5,7 +6,7 @@ import { ReactNode } from "react";
 /**
  * The common props used within the Render Components
  */
-export type RenderComponentProps<T extends object = Record<string, string>> = Readonly<{
+export type RenderComponentProps<T extends Attributes = Attributes> = Readonly<{
   /** The name of the node for debugging reasons */
   nodeName: string;
   /** The type of node this is expected to be */
@@ -13,18 +14,18 @@ export type RenderComponentProps<T extends object = Record<string, string>> = Re
   /** The Node object from the Markup */
   node: Node;
   /** The parsed children of this component */
-  childNodes?: ParsedNode<Record<string, string>>[];
+  childNodes?: ParsedNode<Attributes>[];
   /** The attributes of a node */
   attributes: T;
 }>;
 
 /** The common shared between all Render Components */
-export type RenderComponent<T extends object = Record<string, string>> = (
+export type RenderComponent<T extends Attributes = Attributes> = (
   props: RenderComponentProps<T>
 ) => ReactNode;
 
 /** A bundle of like attributes for a RenderComponent */
-export type RenderComponentDefinition<T extends object = Record<string, string>> = {
+export type RenderComponentDefinition<T extends Attributes = Attributes> = {
   Component: RenderComponent<T>;
   nodeType: NodeType;
   /** True if this component supports children */
@@ -38,7 +39,7 @@ export type RenderComponentDefinition<T extends object = Record<string, string>>
 /**
  * A node parsed into an object for easier rendering
  */
-export type ParsedNode<T extends object = Record<string, string>> = {
+export type ParsedNode<T extends Attributes = Attributes> = {
   /** The unique component key for React */
   key: string;
   /** The component function to render this specific node */

--- a/src/features/dynamicRender/utils/markup/parseLayout.spec.ts
+++ b/src/features/dynamicRender/utils/markup/parseLayout.spec.ts
@@ -1,10 +1,19 @@
+import { AttributeDefinition } from "features/dynamicRender/types/attributes/definition";
 import { __testing__ } from "./parseLayout";
+import { ExpressionType } from "features/dynamicRender/types/expression";
 
 jest.mock("features/dynamicRender/utils/registry");
 
-const { parseNodeChild, parseNodeChildren } = __testing__;
+const {
+  checkForExpression,
+  getAttributeValue,
+  parseAttributes,
+  parseAttributeExpression,
+  parseNodeChild,
+  parseNodeChildren,
+} = __testing__;
 
-const getAttribute: (name: string) => string = jest.fn((name: string) => name);
+const getAttribute: (name: string) => string | null = jest.fn((name: string) => name);
 
 const TAG_NAME = "Box";
 const INVALID_NODE = { nodeType: Node.COMMENT_NODE } as ChildNode;
@@ -13,6 +22,10 @@ const ELEMENT_NODE = {
   tagName: TAG_NAME,
   getAttribute,
   childNodes: [],
+} as unknown as Element;
+const TEXT_NODE = {
+  nodeType: Node.TEXT_NODE,
+  textContent: "some text",
 } as unknown as Element;
 
 describe("parseNodeChildren tests", () => {
@@ -54,5 +67,115 @@ describe("parseNodeChild", () => {
     if (!res) return;
     expect(res.key).toBe(`${TAG_NAME}_1`);
     expect(mockCount.get(TAG_NAME)).toBe(1);
+  });
+});
+
+describe("parseAttributes tests", () => {
+  const ATTRIBUTE_DEFINITIONS: AttributeDefinition[] = [{ name: "test" }];
+  it("returns an empty object for an invalid node", () => {
+    const attributes = parseAttributes(undefined as unknown as Node, ATTRIBUTE_DEFINITIONS);
+    expect(attributes).toStrictEqual({});
+  });
+
+  it("is not a valid node type", () => {
+    const attributes = parseAttributes(INVALID_NODE, ATTRIBUTE_DEFINITIONS);
+    expect(attributes).toStrictEqual({});
+  });
+
+  it("is a text node", () => {
+    const attributes = parseAttributes(TEXT_NODE, ATTRIBUTE_DEFINITIONS);
+    expect(attributes.textContent).toBeDefined();
+  });
+
+  it("skips if invalid attribute definitions", () => {
+    const attributes = parseAttributes(ELEMENT_NODE, undefined as unknown as AttributeDefinition[]);
+    expect(attributes).toStrictEqual({});
+  });
+
+  it("inserts an attribute correctly", () => {
+    const attributes = parseAttributes(ELEMENT_NODE, ATTRIBUTE_DEFINITIONS);
+    expect(attributes[ATTRIBUTE_DEFINITIONS[0].name]).toBeDefined();
+  });
+
+  it("skips undefined variables", () => {
+    // eslint-disable-next-line no-restricted-syntax
+    jest.mocked(getAttribute).mockImplementationOnce(() => null);
+    const attributes = parseAttributes(ELEMENT_NODE, ATTRIBUTE_DEFINITIONS);
+    expect(attributes).toStrictEqual({});
+  });
+});
+
+describe("getAttributeValue tests", () => {
+  const NAME = "testname";
+  const VALUE = "testvalue";
+  const DEFAULT = "defaultvalue";
+
+  beforeEach(() => {
+    jest.mocked(getAttribute).mockClear();
+  });
+
+  it("gets a string value", () => {
+    jest.mocked(getAttribute).mockImplementationOnce(() => VALUE);
+    const { name, value } = getAttributeValue(ELEMENT_NODE, { name: NAME });
+    expect(name).toBe(NAME);
+    expect(value).toBe(VALUE);
+  });
+
+  it("is default value if not found", () => {
+    // eslint-disable-next-line no-restricted-syntax
+    jest.mocked(getAttribute).mockImplementationOnce(() => null);
+
+    const { name, value } = getAttributeValue(ELEMENT_NODE, { name: NAME, default: DEFAULT });
+    expect(name).toBe(NAME);
+    expect(value).toBe(DEFAULT);
+  });
+
+  it("is evaluated as expression", () => {
+    jest.mocked(getAttribute).mockImplementationOnce(() => VALUE);
+    const { name, value } = getAttributeValue(ELEMENT_NODE, {
+      name: NAME,
+      supportsExpressions: true,
+    });
+    expect(name).toBe(NAME);
+    expect(typeof value).toBe("object");
+  });
+});
+
+describe("parseAttributeExpression tests", () => {
+  it("given text is not a string", () => {
+    const expression = parseAttributeExpression(undefined as unknown as string);
+    expect(expression.type).toBe(ExpressionType.Invalid);
+  });
+
+  it("does not have an expression", () => {
+    const expression = parseAttributeExpression("no expressions here");
+    expect(expression.type).toBe(ExpressionType.PlainText);
+  });
+});
+
+describe("checkForExpression tests", () => {
+  it("returns false on non-string", () => {
+    const result = checkForExpression(undefined as unknown as string);
+    expect(result).toBe(false);
+  });
+
+  it("starts with an expression", () => {
+    const result = checkForExpression("${self.name}");
+    expect(result).toBe(true);
+  });
+
+  it("contains an expression", () => {
+    const result = checkForExpression("Hi, my name is ${self.name}");
+    expect(result).toBe(true);
+  });
+
+  it("has an escaped expression", () => {
+    const result = checkForExpression("Hi, my name is \\${self.name}");
+    expect(result).toBe(false);
+  });
+
+  it("has no expression", () => {
+    const result = checkForExpression("I'm afraid you are... expressionless");
+    expect(result).toBe(false);
   });
 });

--- a/src/features/dynamicRender/utils/markup/parseLayout.ts
+++ b/src/features/dynamicRender/utils/markup/parseLayout.ts
@@ -114,14 +114,26 @@ function parseAttributes(node: Node, attributeDefinitions: AttributeDefinition[]
 
   const element = node as Element;
   attributeDefinitions.forEach((definition: AttributeDefinition) => {
-    const name = definition.name;
-    const defaultValue = definition.default ?? undefined;
-    const value = element.getAttribute(name) ?? defaultValue;
+    const { name, value } = getAttributeValue(element, definition);
 
     if (value === undefined) return;
     attributes[name] = value;
   });
   return attributes;
+}
+
+/**
+ * Identifies and fetches an attribute.
+ * @param element - The element node containing the attributes
+ * @param definition - A single attribute definition
+ * @returns An object containing the attribute name and value.
+ */
+function getAttributeValue(element: Element, definition: AttributeDefinition) {
+  const name = definition.name;
+  const defaultValue = definition.default ?? undefined;
+  let value: ExpressionDescriptor | string | undefined = element.getAttribute(name) ?? defaultValue;
+  if (value && definition.supportsExpressions) value = parseAttributeExpression(value);
+  return { name, value };
 }
 
 /**
@@ -186,7 +198,10 @@ function checkForExpression(text: string): boolean {
 }
 
 export const __testing__ = {
+  checkForExpression,
+  getAttributeValue,
   parseAttributes,
+  parseAttributeExpression,
   parseNodeChild,
   parseNodeChildren,
 };

--- a/src/features/dynamicRender/utils/markup/parseLayout.ts
+++ b/src/features/dynamicRender/utils/markup/parseLayout.ts
@@ -1,4 +1,11 @@
+import { Attributes } from "features/dynamicRender/types/attributes";
 import { AttributeDefinition } from "features/dynamicRender/types/attributes/definition";
+import {
+  ExpressionDescriptor,
+  ExpressionType,
+  InvalidExpression,
+  PlainTextExpression,
+} from "features/dynamicRender/types/expression";
 import { ParsedNode } from "features/dynamicRender/types/render";
 import {
   canNodeHaveChildren,
@@ -51,7 +58,7 @@ function parseNodeChildren(childNodes: NodeListOf<ChildNode>): ParsedNode[] {
 function parseNodeChild(
   node: ChildNode,
   nodeTypeCount: Map<string, number>
-): ParsedNode<Record<string, string>> | undefined {
+): ParsedNode<Attributes> | undefined {
   const isUsableNode = checkIfUsableNode(node);
   if (!isUsableNode) return;
 
@@ -89,13 +96,23 @@ function parseNodeChild(
  * @param attributeDefinitions - The definition for the different valid attributes for this kind of node
  * @returns The attributes of a node
  */
-function parseAttributes(node: Node, attributeDefinitions: AttributeDefinition[]) {
-  if (node.nodeType !== Node.ELEMENT_NODE) return {};
+function parseAttributes(node: Node, attributeDefinitions: AttributeDefinition[]): Attributes {
+  if (typeof node !== "object") return {};
+
+  const isElementNode = node?.nodeType === Node.ELEMENT_NODE;
+  const isTextNode = node?.nodeType === Node.TEXT_NODE;
+  if (!isElementNode && !isTextNode) return {};
+
+  const attributes: Attributes = {};
+  if (isTextNode) {
+    const textContent = node.textContent ?? "";
+    attributes.textContent = parseAttributeExpression(textContent);
+    return attributes;
+  }
+
   if (!attributeDefinitions || attributeDefinitions.length === 0) return {};
 
   const element = node as Element;
-  const attributes: Record<string, string> = {};
-
   attributeDefinitions.forEach((definition: AttributeDefinition) => {
     const name = definition.name;
     const defaultValue = definition.default ?? undefined;
@@ -105,6 +122,67 @@ function parseAttributes(node: Node, attributeDefinitions: AttributeDefinition[]
     attributes[name] = value;
   });
   return attributes;
+}
+
+/**
+ * Parses the given text for expression(s), creating an Expression Descriptor that
+ * identifies the variables used and the type of
+ * @param text - The text to parse into an ExpressionDescriptor
+ * @returns Returns an ExpressionDescriptor
+ */
+function parseAttributeExpression(text: string): ExpressionDescriptor {
+  if (typeof text !== "string")
+    return newInvalidExpression("Invalid value given to parseAttributeExpression");
+
+  const hasExpression = checkForExpression(text);
+  if (!hasExpression) {
+    const plainTextExpression: PlainTextExpression = {
+      value: text,
+      type: ExpressionType.PlainText,
+    };
+    return plainTextExpression;
+  }
+
+  return newInvalidExpression(
+    "Attributes requiring expression evaluation is not currently supported",
+    text
+  );
+}
+
+/**
+ * Creates a new invalid expression given the reason for failure and
+ * optionally the triggering expression
+ * @param why - The reason for why this is invalid
+ * @param text - The triggering text, if any
+ * @returns A new invalid expression
+ */
+function newInvalidExpression(why: string, text?: string): InvalidExpression {
+  const invalidExpression: InvalidExpression = {
+    type: ExpressionType.Invalid,
+    why,
+    value: text,
+  };
+  return invalidExpression;
+}
+
+/** Matches an expression at the start of the string */
+const STARTING_EXPRESSION_REGEX = /^\${.+}/;
+/** Matches an expression that occurs later and is not escaped by a leading backslash */
+const NONESCAPED_EXPRESSION_REGEX = /[^\\]\${.+}/;
+
+/**
+ * Checks for an expression within a given string
+ * @param text - The text to check for an expression
+ * @returns True if an expression is found. False otherwise
+ */
+function checkForExpression(text: string): boolean {
+  if (typeof text !== "string") return false;
+
+  const startsWithExpression = STARTING_EXPRESSION_REGEX.test(text);
+  if (startsWithExpression) return true;
+
+  const containsNonEscapedExpression = NONESCAPED_EXPRESSION_REGEX.test(text);
+  return containsNonEscapedExpression;
 }
 
 export const __testing__ = {

--- a/src/features/dynamicRender/utils/node.spec.ts
+++ b/src/features/dynamicRender/utils/node.spec.ts
@@ -1,10 +1,8 @@
-import { getAttributeValue, __testing__ } from "./node";
+import { __testing__ } from "./node";
 
 jest.mock("lib/mobx");
 
 const { checkIfUsableNode, getNodeName } = __testing__;
-
-const getAttribute: (name: string) => string | null = jest.fn((name: string) => name);
 
 const INVALID_NODE = { nodeType: Node.COMMENT_NODE } as ChildNode;
 
@@ -50,41 +48,5 @@ describe("getNodeName tests", () => {
     const mockNode = { nodeType: Node.COMMENT_NODE } as ChildNode;
     const res = getNodeName(mockNode);
     expect(res).toBeUndefined();
-  });
-});
-
-describe("getAttributeValue", () => {
-  const mockAttribute = "mockAttr";
-  const mockDefaultValue = "good, anakin, good";
-
-  beforeEach(() => {
-    jest.mocked(getAttribute).mockClear();
-  });
-
-  test("not an element node", () => {
-    const res = getAttributeValue(INVALID_NODE, mockAttribute, mockDefaultValue);
-    expect(res).toBe(mockDefaultValue);
-  });
-
-  test("missing attribute", () => {
-    // This `null` is required because we are mocking the built-in Element.getAttribute() function,
-    // which returns null when an attribute is not found.
-    // eslint-disable-next-line no-restricted-syntax
-    jest.mocked(getAttribute).mockImplementationOnce(() => null);
-    const mockNode = { nodeType: Node.ELEMENT_NODE, getAttribute } as Element;
-
-    const res = getAttributeValue(mockNode, mockAttribute, mockDefaultValue);
-
-    expect(getAttribute).toHaveBeenCalled();
-    expect(res).toBe(mockDefaultValue);
-  });
-
-  test("successful find", () => {
-    const mockNode = { nodeType: Node.ELEMENT_NODE, getAttribute } as Element;
-
-    const res = getAttributeValue(mockNode, mockAttribute, mockDefaultValue);
-
-    expect(getAttribute).toHaveBeenCalled();
-    expect(res).toBe(mockAttribute);
   });
 });

--- a/src/features/dynamicRender/utils/node.ts
+++ b/src/features/dynamicRender/utils/node.ts
@@ -63,22 +63,8 @@ export function getNodeName(node: ChildNode): string | undefined {
   return undefined;
 }
 
-/**
- * Determines the value of the checkbox. If none is present, the default is 'on'.
- * @param node - The node to extract the checkbox value from
- * @returns The value of the checkbox. Defaults to 'on'.
- */
-export function getAttributeValue(node: Node, attribute: string, defaultValue = ""): string {
-  if (node.nodeType !== Node.ELEMENT_NODE) return defaultValue;
-
-  const element = node as Element;
-  const value: string | null = element.getAttribute(attribute);
-  if (value === null) return defaultValue;
-
-  return value.trim();
-}
-
 export const __testing__ = {
+  canNodeHaveChildren,
   checkIfUsableNode,
   getNodeName,
 };

--- a/src/features/dynamicRender/utils/node.ts
+++ b/src/features/dynamicRender/utils/node.ts
@@ -7,6 +7,8 @@ import { getRenderComponentBundle } from "features/dynamicRender/utils/registry"
  * @returns True if the node can be used, false otherwise
  */
 export function checkIfUsableNode(node: ChildNode): boolean {
+  if (typeof node !== "object") return false;
+
   const nodeType = node.nodeType;
   switch (nodeType) {
     case Node.TEXT_NODE: {
@@ -27,9 +29,9 @@ export function checkIfUsableNode(node: ChildNode): boolean {
  */
 export function canNodeHaveChildren(nodeType: NodeType): boolean {
   const componentDefinition = getRenderComponentBundle(nodeType);
-  if (!componentDefinition) false;
+  if (typeof componentDefinition !== "object") return false;
 
-  return componentDefinition.allowsChildren;
+  return componentDefinition.allowsChildren ?? false;
 }
 
 /**

--- a/src/features/dynamicRender/utils/registry.ts
+++ b/src/features/dynamicRender/utils/registry.ts
@@ -1,6 +1,7 @@
 import { voidBundle } from "features/dynamicRender/components/utility/Void";
+import { Attributes } from "features/dynamicRender/types/attributes";
 import { NodeType } from "features/dynamicRender/types/node";
-import { RenderComponentDefinition } from "features/dynamicRender/types/render";
+import { RenderComponent, RenderComponentDefinition } from "features/dynamicRender/types/render";
 import { observer } from "lib/mobx";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -11,11 +12,11 @@ const dynamicComponentRegistry = new Map<NodeType, RenderComponentDefinition<any
  * @param nodeName - The name of the node to register this component under
  * @param component - The component to register
  */
-export function registerComponentDefinition<T extends object>(
+export function registerComponentDefinition<T extends Attributes>(
   componentDefinition: RenderComponentDefinition<T>
 ) {
   const nodeType = componentDefinition.nodeType;
-  const Component = observer(componentDefinition.Component);
+  const Component: RenderComponent<T> = observer(componentDefinition.Component);
 
   dynamicComponentRegistry.set(nodeType, {
     ...componentDefinition,
@@ -37,7 +38,9 @@ export function registerComponentDefinition<T extends object>(
  * @param nodeName - The name under which a Component is registered
  * @returns A Render Component function
  */
-export function getRenderComponentBundle(nodeType: NodeType): RenderComponentDefinition {
+export function getRenderComponentBundle(
+  nodeType: NodeType
+): RenderComponentDefinition<Attributes> {
   const bundle = dynamicComponentRegistry.get(nodeType);
   if (!bundle) return voidBundle;
   return bundle;


### PR DESCRIPTION
Changes:
- Creates Attribute types that are either an Expression or string
- Creates a step for parsing expressions while processing an attribute
- Adds support for plain text expressions (that is, text that does not need processing)

Testing
- On local, any text that is not "TODO" is a valid PlainText attribute
- Anything that is "TODO" is an expression that requires computing (and not currently supported) 